### PR TITLE
[unixhttp] improve error reporting on URLError exceptions

### DIFF
--- a/accelerator/unixhttp.py
+++ b/accelerator/unixhttp.py
@@ -113,13 +113,13 @@ def call(url, data=None, fmt=json_decode, headers={}, server_name='server', retr
 				break
 			if server_name == 'server' and e.code != 503 and resp:
 				return fmt(resp)
-		except URLError:
+		except URLError as e:
 			# Don't say anything the first times, because the output
 			# tests get messed up if this happens during them.
 			if attempt < retries - 1:
 				msg = None
 			else:
-				msg = 'error contacting ' + server_name
+				msg = 'error contacting %s: %s' % (server_name, e.reason)
 		except ValueError as e:
 			msg = 'Bad data from %s, %s: %s' % (server_name, type(e).__name__, e,)
 		if msg and not quiet:


### PR DESCRIPTION
Hello again :D Sofia said any way of contacting you should work in principle, so let's just start with code sharing :)

So I was testing the accelerator in an automated testing setup at Combine, and bumped into the issue that the sockets for communication had too long paths and were failing to be created with a message similar to `AF_UNIX path too long`. However, the accelerator was swallowing that information, which gave me absolutely no clue of what was going on until I poked into the code. This PR improves  that by presenting the reason for the error.