### PR TITLE
[extras] add merge_safe as an alternative to merge_auto

### DIFF
--- a/accelerator/standard_methods/a_dataset_fanout_collect.py
+++ b/accelerator/standard_methods/a_dataset_fanout_collect.py
@@ -42,4 +42,4 @@ def analysis(sliceno):
 	return set(imap(unicode, chain.iterate(sliceno, options.column)))
 
 def synthesis(analysis_res):
-	return analysis_res.merge_auto()
+	return analysis_res.merge_auto(allow_overwrite=True)

--- a/accelerator/test_methods/a_test_dataset_fanout.py
+++ b/accelerator/test_methods/a_test_dataset_fanout.py
@@ -67,7 +67,7 @@ def synthesis(job):
 	j_a_C = subjobs.build('dataset_fanout', source=a, column='C')
 	chk(j_a_C, 'AB', ('unicode', 'ascii'), {'1': [('a', 'a')], '2': [('b', 'b')], '3': [('a', 'c')]}, hashlabel='A')
 
-	b = mk('b', ('ascii', 'unicode', 'int32', 'int32'), [('a', 'aa', 11, 111), ('b', 'bb', 12, 112), ('a', 'cc', 13, 113), ('d', 'dd', 14, 114)], previous=a)
+	b = mk('b', ('ascii', 'unicode', 'int32', 'int32'), [('a', 'aa', 11, 111), ('b', 'bb', 12, 112), ('a', 'cc', 13, 113), ('d', 'dd', 14, 114)], hashlabel=a.hashlabel, previous=a)
 	# with previous
 	j_b_A = subjobs.build('dataset_fanout', source=b, column='A', previous=j_a_A)
 	chk(


### PR DESCRIPTION
Sofia has recurrently expressed dissatisfaction with merge_auto not working super well at reproducing data due to the update in some data types not being fit for data science. For example, while Counter's update does what one would expect, dict's update might simply override previous values from the iterator without giving out any feedback. To allow data scientists to avoid this issue, we add a new API that makes sure that previous values don't exist.

This is probably missing tests and some further discussion (like, should we consider the `Counter` type safe?), so marking it as draft